### PR TITLE
Update 2.2.1-Pytorch编写完整的Transformer.md

### DIFF
--- a/docs/篇章2-Transformer相关原理/2.2.1-Pytorch编写完整的Transformer.md
+++ b/docs/篇章2-Transformer相关原理/2.2.1-Pytorch编写完整的Transformer.md
@@ -605,7 +605,7 @@ class TransformerEncoderLayer(nn.Module):
         src = src + self.dropout1(src2)
         src = self.norm1(src)
         src2 = self.linear2(self.dropout(self.activation(self.linear1(src))))
-        src = src + self.dropout(src2)
+        src = src + self.dropout2(src2)
         src = self.norm2(src)
         return src
 


### PR DESCRIPTION
看了代码有个地方应该是少写了一个2
主要看了encoder和decoder的结构。分词器和注意力没细看，导致有一点不太确定，希望能请教一下。
1.代码中memory是encoder最后一层输出，是不是就是教程里的Z，形状和encoder输入一样？
2.在decoder中第二层encoder-decoder-attention层的k和v是来自memory，但每层这个k、v是一样的，还是得乘以每层不同的权重矩阵？
3.sgt是上一层输出，第一层是目标序列的输入对吧？比如第一个预测字符<start>，后续的预测结果加入这个输入序列
4.看代码encoder和decoder每层内部（自注意力和FFNN）已经有了norm，是不是默认最后输出还要进行一次norm？
5.为啥最后encoder和decode输出还要要norm？
暂时这几个问题，麻烦各位大佬了
